### PR TITLE
standard

### DIFF
--- a/commands/publish.js
+++ b/commands/publish.js
@@ -26,7 +26,7 @@ module.exports = Command.extend({
         }
 
         var version = {
-          hash: res[res.length - 1].Hash,
+          hash: res[res.length - 2].Hash,
           timestamp: new Date()
         }
         console.log(version)

--- a/commands/publish.js
+++ b/commands/publish.js
@@ -26,7 +26,7 @@ module.exports = Command.extend({
         }
 
         var version = {
-          hash: res[res.length - 2].Hash,
+          hash: res[res.length - 1].Hash,
           timestamp: new Date()
         }
         console.log(version)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Quick and simple deploy tool to host Native Web Applications and Static Web Pages in IPFS",
   "bin": "bin.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "standard"
   },
   "repository": {
     "type": "git",
@@ -27,5 +27,8 @@
     "open": "0.0.5",
     "ronin": "^0.3.11",
     "webshot": "^0.16.0"
+  },
+  "devDependencies": {
+    "standard": "^5.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,12 @@
   "description": "Quick and simple deploy tool to host Native Web Applications and Static Web Pages in IPFS",
   "bin": "bin.js",
   "scripts": {
-    "test": "standard"
+    "lint": "standard",
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "pre-commit": [
+    "lint"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/diasdavid/ipscend.git"
@@ -29,6 +33,7 @@
     "webshot": "^0.16.0"
   },
   "devDependencies": {
+    "pre-commit": "^1.1.2",
     "standard": "^5.4.1"
   }
 }


### PR DESCRIPTION
`ipscend` is already using StandardJS -- this just adds it to `npm test`. It'd also work as a pre-commit hook though.
